### PR TITLE
Read env vars for secret key and DB URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # manav-web
 
+Uygulama `MANAV_SECRET_KEY` ve `MANAV_DB_URI` adında iki ortam değişkeni okur.
+Bu değişkenler tanımlı değilse sırasıyla `bizim cok zor gizli sozcugumuz` ve
+`mongodb://localhost:27017/` değerleri kullanılacaktır.
+
 Kullanıcı tablosu oluşturulmalı
 admin kullanıcısı için:
 

--- a/main.py
+++ b/main.py
@@ -1,13 +1,15 @@
 import base64
 import datetime
+import os
 from flask import Flask, render_template, request, redirect, session
 import pymongo
 from bson.objectid import ObjectId
 
 app = Flask(__name__)
-app.secret_key = 'bizim cok zor gizli sozcugumuz'
+app.secret_key = os.environ.get("MANAV_SECRET_KEY", "bizim cok zor gizli sozcugumuz")
 
-myclient = pymongo.MongoClient("mongodb://localhost:27017/")
+db_uri = os.environ.get("MANAV_DB_URI", "mongodb://localhost:27017/")
+myclient = pymongo.MongoClient(db_uri)
 mydb = myclient["manavDB"]
 kullanicilar_tablosu = mydb["kullanicilar"]
 urunler_tablosu = mydb["urunler"]


### PR DESCRIPTION
## Summary
- fetch MANAV_SECRET_KEY and MANAV_DB_URI from environment
- document new environment variables in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687a7d9eebf4832e85b7cdc6a1102d4b